### PR TITLE
Excluding db migration generated classes

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,6 +2,8 @@ sonar.projectKey=ledgerleapllc_CasperAssociationPortalBackend
 sonar.organization=ledgerleapllc
 sonar.php.coverage.reportPaths=coverage.xml
 
+sonar.coverage.exclusions=database/migrations/**/*
+
 # This is the name and version displayed in the SonarCloud UI.
 #sonar.projectName=CasperAssociationPortalBackend
 #sonar.projectVersion=1.0


### PR DESCRIPTION
The database/migrations clasess do not need to be included in the test coverage report as they are part of Laravel core and  generated by the command `php artisan make:migration migration_table` to draft database schema updates as needed.